### PR TITLE
Fix Generate Dummy Secret Behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ files:
 
 ## Generate Dummy Secret
 
-There is some case where our local machine don't have access to the decryptor key, but we still want ksops to just output or keep producing a secret with a dummy value in it. 
+There is a case where our machine does not have an access to the decryptor key (i.e. our CICD), but we still want ksops to keep producing a secret with a placeholder 'secret' value in it.
 
 With `fail-silently` set to `true`, ksops will outputing an `failed decrypting file` error message with 0 (zero) exit code. 
 

--- a/README.md
+++ b/README.md
@@ -33,3 +33,11 @@ fail-silently: true
 files:
 - ./secret.enc.yaml
 ```
+
+## Generate Dummy Secret
+
+There is some case where our local machine don't have access to the decryptor key, but we still want ksops to just output or keep producing a secret with a dummy value in it. 
+
+With `fail-silently` set to `true`, ksops will outputing an `failed decrypting file` error message with 0 (zero) exit code. 
+
+In order to generate a dummy secret without error message above, we need set `KSOPS_GENERATE_DUMMY_SECRETS` environment variable to `TRUE`. e.g `KSOPS_GENERATE_DUMMY_SECRETS=TRUE kustomize build --enable-alpha-plugins <dir>`

--- a/main.go
+++ b/main.go
@@ -72,19 +72,20 @@ func main() {
 		data, err = decrypt.DataWithFormat(b, format)
 
 		if err != nil {
-			if manifest.FailSilently {
-				if isGenerateDummy {
-					dummySecret := generateDummySecret(b)
-					output.Write(dummySecret)
-					output.WriteString("\n---\n")
-				} else {
+			if isGenerateDummy {
+				dummySecret := generateDummySecret(b)
+				output.Write(dummySecret)
+				output.WriteString("\n---\n")
+			} else {
+				if manifest.FailSilently {
 					_, _ = fmt.Fprintf(os.Stderr, "failed decrypting file '%s': %s\n", file, err.Error())
 					os.Exit(0)
+				} else {
+					_, _ = fmt.Fprintf(os.Stderr, "failed decrypting file '%s': %s\n", file, err.Error())
+					os.Exit(1)
 				}
-			} else {
-				_, _ = fmt.Fprintf(os.Stderr, "failed decrypting file '%s': %s\n", file, err.Error())
-				os.Exit(1)
 			}
+
 		}
 
 		output.Write(data)


### PR DESCRIPTION
Current behavior, we need both `fail-silently` (in secret-generator yaml file) and `KSOPS_GENERATE_DUMMY_SECRETS` environment variable to `true` to generate dummy secret.

This PR intended to fix this behavior, so "generate dummy secret" feature can work independently from `fail-silently`.
